### PR TITLE
Avoid things that are deprecated in Symfony or SimpleSAMLphp.

### DIFF
--- a/Security/Authenticator/SSPGuardAuthenticator.php
+++ b/Security/Authenticator/SSPGuardAuthenticator.php
@@ -53,22 +53,21 @@ abstract class SSPGuardAuthenticator extends AbstractGuardAuthenticator
         $this->authSourceId = $authSourceId;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request)
+    {
+        $match = $this->router->match($request->getPathInfo());
+        return 'ssp_guard_check' === $match['_route'] &&
+            $this->authSourceId === $match['authSource'];
+    }
 
     /**
      * {@inheritdoc}
      */
     public function getCredentials(Request $request)
     {
-        $match = $this->router->match($request->getPathInfo());
-
-        if (
-            'ssp_guard_check' !== $match['_route']
-            || $this->authSourceId !== $match['authSource']
-        ) {
-            // skip authentication unless we're on this route
-            return;
-        }
-
         $this->authSource = $this->authSourceRegistry->getAuthSource($this->authSourceId);
 
         return $this->authSource->getCredentials();

--- a/SimpleSAMLphp/SSPAuthSource.php
+++ b/SimpleSAMLphp/SSPAuthSource.php
@@ -30,7 +30,7 @@ class SSPAuthSource
      */
     public function __construct($authSource, array $options = [])
     {
-        $this->auth = new \SimpleSAML_Auth_Simple($authSource);
+        $this->auth = new \SimpleSAML\Auth\Simple($authSource);
         $this->options = $options;
     }
 


### PR DESCRIPTION
Saves us some deprecation warnings in the logs (or breakage with future versions).