### PR TITLE
Do not require authSourceId to be passed to Authenticator constructor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ And create the service definition, e.g.:
 <service id="app.admin.authenticator" class="AppBundle\Security\AdminAuthenticator">
     <argument type="service" id="router"/>
     <argument type="service" id="ssp.guard.registry"/>
-    <argument>admin</argument> <!-- this is the authsource id -->
 </service>
 ```
 
@@ -136,7 +135,7 @@ or in `app/config/services.yml`:
 
 ```yml
 AppBundle\Security\AdminAuthenticator:
-    arguments: ["@router", "@ssp.guard.registry", "admin"] 
+    arguments: ["@router", "@ssp.guard.registry"]
 ```
 
 ### Step 6: Create a custom User Provider

--- a/Security/Authenticator/SSPGuardAuthenticator.php
+++ b/Security/Authenticator/SSPGuardAuthenticator.php
@@ -35,10 +35,6 @@ abstract class SSPGuardAuthenticator extends AbstractGuardAuthenticator
      * @var SSPAuthSource
      */
     protected $authSource = null;
-    /**
-     * @var
-     */
-    protected $authSourceId;
 
     /**
      * SSPGuardAuthenticator constructor.
@@ -46,11 +42,10 @@ abstract class SSPGuardAuthenticator extends AbstractGuardAuthenticator
      * @param Router $router
      * @param AuthSourceRegistry $authSourceRegistry
      */
-    public function __construct(Router $router, AuthSourceRegistry $authSourceRegistry, $authSourceId)
+    public function __construct(Router $router, AuthSourceRegistry $authSourceRegistry)
     {
         $this->router = $router;
         $this->authSourceRegistry = $authSourceRegistry;
-        $this->authSourceId = $authSourceId;
     }
 
     /**
@@ -59,8 +54,7 @@ abstract class SSPGuardAuthenticator extends AbstractGuardAuthenticator
     public function supports(Request $request)
     {
         $match = $this->router->match($request->getPathInfo());
-        return 'ssp_guard_check' === $match['_route'] &&
-            $this->authSourceId === $match['authSource'];
+        return 'ssp_guard_check' === $match['_route'];
     }
 
     /**
@@ -68,7 +62,8 @@ abstract class SSPGuardAuthenticator extends AbstractGuardAuthenticator
      */
     public function getCredentials(Request $request)
     {
-        $this->authSource = $this->authSourceRegistry->getAuthSource($this->authSourceId);
+        $match = $this->router->match($request->getPathInfo());
+        $this->authSource = $this->authSourceRegistry->getAuthSource($match['authSource']);
 
         return $this->authSource->getCredentials();
     }


### PR DESCRIPTION
Hi Sergio,

When following the documentation at Step 8 I have a neat twig snippet that will iterate over my _n_ authsources and present a "login with x" button for each, which just iterates over the configuration in config.yml.

However, this does not work out of the box because outside of config.yml, the authsourceid also needs to be passed to the class constructor. So besides the configuration in config.yml you also need to add boilerplate for each authsource, I think.

In this proposed change I just removed the need to pass the authsource to the constructor. This means the authsource name(s) are configured only in one place. And changing it or adding another one only happens there.

It works for me but I might be missing why it was required to pass in an authsource to the constructor. So maybe this breaks something/a different use case? Perhaps you can shed a light on this.

Thanks,
Thijs

